### PR TITLE
Prevent serializing empty optional values in `IntentFilterData`

### DIFF
--- a/ndk-build2/src/manifest.rs
+++ b/ndk-build2/src/manifest.rs
@@ -317,19 +317,19 @@ where
 /// Android [intent filter data 元素](https://developer.android.com/guide/topics/manifest/data-element).
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct IntentFilterData {
-    #[serde(rename(serialize = "@android:scheme"))]
+    #[serde(rename(serialize = "@android:scheme"), skip_serializing_if = "Option::is_none")]
     pub scheme: Option<String>,
-    #[serde(rename(serialize = "@android:host"))]
+    #[serde(rename(serialize = "@android:host"), skip_serializing_if = "Option::is_none")]
     pub host: Option<String>,
-    #[serde(rename(serialize = "@android:port"))]
+    #[serde(rename(serialize = "@android:port"), skip_serializing_if = "Option::is_none")]
     pub port: Option<String>,
-    #[serde(rename(serialize = "@android:path"))]
+    #[serde(rename(serialize = "@android:path"), skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
-    #[serde(rename(serialize = "@android:pathPattern"))]
+    #[serde(rename(serialize = "@android:pathPattern"), skip_serializing_if = "Option::is_none")]
     pub path_pattern: Option<String>,
-    #[serde(rename(serialize = "@android:pathPrefix"))]
+    #[serde(rename(serialize = "@android:pathPrefix"), skip_serializing_if = "Option::is_none")]
     pub path_prefix: Option<String>,
-    #[serde(rename(serialize = "@android:mimeType"))]
+    #[serde(rename(serialize = "@android:mimeType"), skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<String>,
 }
 


### PR DESCRIPTION
Fixes install failure when optional fields in `package.metadata.android.application.activity.intent_filter` are not provided. Currently, optional fields which are not specified in `data` are also included in generated `AndroidManifest.xml` with empty value which leads to parsing exception:
```
Failure [INSTALL_PARSE_FAILED_UNEXPECTED_EXCEPTION: Failed parse during installPackageLI: Failed to read manifest from /data/app/vmdl66139237.tmp/base.apk: For input string: ""]
``` 