### PR TITLE
Fix `NoClassDefFoundError` by bundling `kotlin-stdlib` classes into dex output

### DIFF
--- a/cargo-apk2/src/apk.rs
+++ b/cargo-apk2/src/apk.rs
@@ -15,7 +15,7 @@ use {
     std::{
         env::var,
         ffi::OsStr,
-        fs::{create_dir_all, read_dir},
+        fs::{copy, create_dir_all, read_dir, remove_dir_all},
         path::{Path, PathBuf},
         process::{Command, Stdio},
     },
@@ -334,6 +334,77 @@ impl<'a> ApkBuilder<'a> {
             return Err(Error::CmdFailed(Box::new(kotlinc)));
         }
 
+        self.bundle_kotlin_stdlib()?;
+
+        Ok(())
+    }
+
+    /// After compiling .kt sources, copy `kotlin-stdlib`'s classes into
+    /// `classes_dir` so they end up in the final dex. `kotlinc -d classes_dir`
+    /// only writes the classes it compiled; it does not copy the runtime
+    /// classes those classes depend on (e.g. `kotlin.jvm.internal.Intrinsics`),
+    /// which crashes at runtime with `NoClassDefFoundError` if omitted.
+    fn bundle_kotlin_stdlib(&self) -> Result<(), Error> {
+        let stdlib_jar = self
+            .kotlin_home
+            .as_ref()
+            .ok_or(Error::KotlinNotFound)?
+            .join("lib")
+            .join("kotlin-stdlib.jar");
+        if !stdlib_jar.exists() {
+            return Err(Error::PathNotFound(stdlib_jar));
+        }
+
+        let jar_tool = self
+            .java_home
+            .as_ref()
+            .ok_or(Error::JdkNotFound)?
+            .join("bin")
+            .join(if cfg!(windows) { "jar.exe" } else { "jar" });
+
+        let scratch = self.classes_dir.join(".kotlin-stdlib-extract");
+        let _ = remove_dir_all(&scratch);
+        create_dir_all(&scratch)?;
+
+        let mut jar = Command::new(&jar_tool);
+        jar.stdin(Stdio::null())
+            .arg("xf")
+            .arg(&stdlib_jar)
+            .current_dir(&scratch);
+        if !jar.status()?.success() {
+            return Err(Error::CmdFailed(Box::new(jar)));
+        }
+
+        // Manifest / .kotlin_module / multi-release module-info.class have no
+        // business being dexed.
+        let meta_inf = scratch.join("META-INF");
+        if meta_inf.exists() {
+            remove_dir_all(&meta_inf)?;
+        }
+
+        Self::copy_class_files_recursive(&scratch, &self.classes_dir)?;
+        remove_dir_all(&scratch)?;
+        Ok(())
+    }
+
+    fn copy_class_files_recursive<P, Q>(src: P, dest: Q) -> Result<(), Error>
+    where
+        P: AsRef<Path>,
+        Q: AsRef<Path>,
+    {
+        let (src, dest) = (src.as_ref(), dest.as_ref());
+        for entry in read_dir(src)? {
+            let entry = entry?;
+            let path = entry.path();
+            let target = dest.join(entry.file_name());
+
+            if path.is_dir() {
+                create_dir_all(&target)?;
+                Self::copy_class_files_recursive(&path, &target)?;
+            } else if path.extension() == Some(OsStr::new("class")) {
+                copy(&path, &target)?;
+            }
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

Any non-trivial `.kt` file compiled via `kotlin_sources` crashes at runtime with:

```
java.lang.NoClassDefFoundError: Failed resolution of: Lkotlin/jvm/internal/Intrinsics;
...
Caused by: java.lang.ClassNotFoundException: Didn't find class "kotlin.jvm.internal.Intrinsics" on path: DexPathList[...]
```

### Minimal repro

```kotlin
// MainActivity.kt
package com.example.app

import android.app.Activity
import android.os.Bundle

class MainActivity : Activity() {
    companion object {
        init { System.loadLibrary("yourlib") }
    }

    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        greet("world")
    }

    private fun greet(name: String) {
        // The Kotlin compiler injects an implicit
        // Intrinsics.checkNotNullParameter(name, "name") here for any
        // non-null parameter — this is enough to trigger the crash,
        // no special stdlib usage required.
        println("Hello, $name")
    }
}
```

```toml
# Cargo.toml
[package.metadata.android]
kotlin_sources = "src/kotlin"
```

`cargo apk2 run` builds and installs successfully, but the app crashes immediately on launch with the `NoClassDefFoundError` above. A functionally-identical `.java` version of the same `Activity` works fine, which is what makes this easy to misdiagnose as an app-level bug rather than a build-tooling one.

### Fix

In `compile_kotlin_sources()`, after `kotlinc` finishes, we now invoke a helper (`bundle_kotlin_stdlib()`) to merge stdlib classes into `classes_dir`:

1. Locates `kotlin-stdlib.jar` via `self.kotlin_home` (`$KOTLIN_HOME/lib/kotlin-stdlib.jar`).
2. Extracts the JAR into a temporary scratch directory using the JDK `jar` tool (`self.java_home`).
3. Strips `META-INF/` so manifests and metadata aren't included in the dex step.
4. Recursively copies remaining `.class` files into `self.classes_dir` before cleaning up the scratch dir.

### Notes

* Reuses existing `kotlin_home` and `java_home` paths; no new flags or environment variables added.
* Only triggers when `kotlin_sources` is set and `.kt` files are actively compiled.
* Java-only builds are unaffected.

### Testing

* **Reproduction & Fix:** Verified on an Android project with Kotlin activity sources. Before this change, the app crashed immediately on launch. After the change, it launches and runs as expected.
* **Dex Inspection:** Inspected `classes.dex` via `dexdump -d` to confirm `Lkotlin/jvm/internal/Intrinsics;.checkNotNullParameter` and other stdlib references resolve to actual method bodies.
* **Cleanup:** Verified `.kotlin-stdlib-extract` scratch directories are deleted post-build and do not persist across runs.
* **Tooling:** `cargo fmt --check` and `cargo clippy -p cargo-apk2 -- -D warnings` both pass.