### PR TITLE
Create "manifest_override" feature 

### DIFF
--- a/cargo-apk2/README.md
+++ b/cargo-apk2/README.md
@@ -85,6 +85,12 @@ Make sure you have an Android device connected via `adb` and have installed `car
 # Use `aapt2` instead of `aapt` for compiling application resources.
 use_aapt2 = true
 
+# You should not need to use this setting, but you might need to if you are attempting to use Android Manifest features
+# that are currently not supported by `cargo-apk2`yet. This setting will cause `cargo-apk2` to COPY the
+# specified AndroidManifest.xml file instead of generating one from the manifest settings in Cargo.toml.
+# Note: you still need to define all the Cargo.toml basics as the tooling requires them for other purposes. 
+mainfest_override = "path/to/AndroidManifest.xml"
+
 # Specifies the package property of the manifest.
 # See https://developer.android.com/guide/topics/manifest/manifest-element#package
 package = "com.foo.bar"

--- a/cargo-apk2/src/apk.rs
+++ b/cargo-apk2/src/apk.rs
@@ -632,6 +632,11 @@ impl<'a> ApkBuilder<'a> {
             .runtime_libs
             .as_ref()
             .map(|libs| dunce::simplified(&crate_path.join(libs)).to_owned());
+        let manifest_override = self
+            .manifest
+            .manifest_override
+            .as_ref()
+            .map(|xml| dunce::simplified(&crate_path.join(xml)).to_owned());
         let apk_name = self
             .manifest
             .apk_name
@@ -653,6 +658,7 @@ impl<'a> ApkBuilder<'a> {
             disable_aapt_compression: is_debug_profile,
             strip: self.manifest.strip,
             reverse_port_forward: self.manifest.reverse_port_forward.clone(),
+            manifest_override: manifest_override.clone(),
         };
         let mut apk = config.create_apk(&gen_java_dir)?;
 

--- a/cargo-apk2/src/manifest.rs
+++ b/cargo-apk2/src/manifest.rs
@@ -35,6 +35,7 @@ pub(crate) struct Manifest {
     pub(crate) signing: HashMap<String, Signing>,
     pub(crate) reverse_port_forward: HashMap<String, String>,
     pub(crate) strip: StripConfig,
+    pub(crate) manifest_override: Option<PathBuf>,
 }
 
 impl Manifest {
@@ -68,6 +69,7 @@ impl Manifest {
             signing: metadata.signing,
             reverse_port_forward: metadata.reverse_port_forward,
             strip: metadata.strip,
+            manifest_override: metadata.manifest_override,
         })
     }
 }
@@ -113,6 +115,7 @@ struct AndroidMetadata {
     apk_name: Option<String>,
     /// 使用aapt2编译和处理资源（默认开启）
     use_aapt2: Option<bool>,
+    manifest_override: Option<PathBuf>,
     #[serde(flatten)]
     android_manifest: AndroidManifest,
     #[serde(default)]

--- a/ndk-build2/src/apk.rs
+++ b/ndk-build2/src/apk.rs
@@ -47,6 +47,7 @@ pub struct ApkConfig {
     pub disable_aapt_compression: bool,
     pub strip: StripConfig,
     pub reverse_port_forward: HashMap<String, String>,
+    pub manifest_override: Option<PathBuf>,
 }
 
 impl ApkConfig {
@@ -68,12 +69,22 @@ impl ApkConfig {
         self.build_dir.join(format!("{}.apk", self.apk_name))
     }
 
+    pub fn copy_file(&self, src: &Path, dst: &Path) -> Result<(), NdkError> {
+        let dst_path = self.build_dir.join(dst);
+        copy(src, dst_path)?;
+        Ok(())
+    }
+
     pub fn create_apk<P>(&self, gen_java_dir: P) -> Result<UnalignedApk<'_>, NdkError>
     where
         P: AsRef<Path>,
     {
         create_dir_all(&self.build_dir)?;
-        self.manifest.write_to(&self.build_dir)?;
+        if let Some(manifest_override) = &self.manifest_override {
+            self.copy_file(&manifest_override, "AndroidManifest.xml".as_ref())?;
+        } else {
+            self.manifest.write_to(&self.build_dir)?;
+        }
 
         let target_sdk_version = self
             .manifest


### PR DESCRIPTION
This allows an escape hatch to declare a custom AndroidManifest.xml file to be copied rather than have  it be generated. 

In my specific case their are several items that the  current  generator doesn't support , and this now makes this tool (at least in the Android Manifest) easily forward compatible immediately as if the generator doesn't work you can override it with your own.